### PR TITLE
Enable logs persistance, so log file can be accesed via the official …

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -8,4 +8,4 @@ export JAVA_HOME=$OPENSHIFT_DATA_DIR/jdk1.8.0_65
 export PATH=$JAVA_HOME/bin:$PATH
 
 cd $OPENSHIFT_REPO_DIR
-nohup java -Xms384m -Xmx412m -jar build/libs/*.jar --server.port=${OPENSHIFT_DIY_PORT} --server.address=${OPENSHIFT_DIY_IP} --spring.profiles.active=openshift &
+nohup java -Xms384m -Xmx412m -jar build/libs/*.jar --server.port=${OPENSHIFT_DIY_PORT} --server.address=${OPENSHIFT_DIY_IP} --spring.profiles.active=openshift --logging.file=${OPENSHIFT_LOG_DIR}app.log &


### PR DESCRIPTION
Enable logs persistence, so log file can be accessed via the official  [rhc](https://developers.openshift.com/managing-your-applications/client-tools.html) client. To monitor logs in real time execute :
  `rhc <app-name> tail`
